### PR TITLE
Defaulting nullable array fields to be [] instead of null

### DIFF
--- a/src/ArrayType.php
+++ b/src/ArrayType.php
@@ -237,7 +237,7 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  return is_countable($this->' . $this->field->getName() . ') ? count($this->' . $this->field->getName() . ') : ($this->' . $this->field->getName() . ' ? 1 : 0);',
+            '  return count($this->' . $this->field->getName() . ');',
             $countDock
         );
         $this->class->addFunction($count);

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -104,7 +104,8 @@ class ComplexType extends Type
 
             $comment = new PhpDocComment();
             $comment->setVar(PhpDocElementFactory::getVar($type, $name, ''));
-            $var = new PhpVariable('protected', $name, 'null', $comment);
+            $defaultVarVal = $member->isArray() ? '[]' : 'null';
+            $var = new PhpVariable('protected', $name, $defaultVarVal, $comment);
             $this->class->addVariable($var);
 
             if (!$member->getNullable()) {
@@ -165,7 +166,7 @@ class ComplexType extends Type
                     // If the type of a member is nullable we should allow passing null to the setter. If the type
                     // of the member is a class and not a primitive this is only possible if setter parameter has
                     // a default null value. We can detect whether the type is a class by checking the type hint.
-                    $member->getNullable() && !empty($typeHint)
+                    !$member->isArray() && $member->getNullable() && !empty($typeHint)
                 ),
                 $setterCode,
                 $setterComment
@@ -287,7 +288,9 @@ class ComplexType extends Type
             if (!empty($type) && $includeType) {
                 $parameterString = $type . ' ' . $parameterString;
             }
-            if ($defaultNull) {
+            if ($type === 'array') {
+                $parameterString .= ' = []';
+            } else if ($defaultNull) {
                 $parameterString .= ' = null';
             }
             $parameterStrings[] = $parameterString;

--- a/src/Variable.php
+++ b/src/Variable.php
@@ -69,6 +69,7 @@ class Variable
      */
     public function isArray()
     {
-        return substr($this->type, -2, 2) == '[]';
+        return substr($this->type, -2, 2) == '[]'
+            || (substr($this->type, 0, 7) == 'ArrayOf');
     }
 }


### PR DESCRIPTION
These changes make it so nullable array fields default to [] instead of null since the previously default null values were causing a lot of issues with implementing arrayable and other implementations.